### PR TITLE
Throwable for the verification blocks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,16 +9,17 @@ jobs:
       GRADLE_OPTS: "-Xmx6g -Xms4g"
       CI: true
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
-      - uses: gradle/actions/setup-gradle@v3
+          java-version: '8'
+          distribution: 'zulu'
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew check coveralls --stacktrace
       - name: Show Reports
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: reports

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
       - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew check coveralls --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,15 @@ jobs:
     env:
       GRADLE_OPTS: "-Xmx6g -Xms4g"
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: '8'
+          distribution: 'zulu'
       - name: Decode PGP
         id: write_file
-        uses: timheuer/base64-to-file@v1
+        uses: timheuer/base64-to-file@v1.2
         with:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       GRADLE_OPTS: "-Xmx6g -Xms4g"
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
       - name: Decode PGP
         id: write_file

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,9 +107,6 @@ config {
             aggregate {
                 enabled = false
             }
-        }
-        sourceHtml {
-            enabled = false
         }
     }
 }

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2024 Vladimir Orany.
+# Copyright 2024-2025 Vladimir Orany.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ group=builders.dsl
 
 version=1.0.0-SNAPSHOT
 
-kordampVersion=0.47.0
+kordampVersion=0.54.0
 nexusPluginVersion=1.0.0
 
 junitVersion=5.3.0

--- a/gradle/LICENSE_HEADER
+++ b/gradle/LICENSE_HEADER
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Apache-2.0
 
-Copyright 2024 ${author}.
+Copyright 2024-2025 ${author}.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri May 01 18:55:16 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.6-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/libs/expectations/expectations.gradle
+++ b/libs/expectations/expectations.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/Expectations.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/Expectations.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion1.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion1.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,6 @@ public interface Assertion1<A> {
      * @param a the parameter to verify
      * @return {@code true} if the test for the given parameter passes, {@code false} otherwise
      */
-    boolean verify(A a);
+    boolean verify(A a) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion10.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion10.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,6 @@ public interface Assertion10<A, B, C, D, E, F, G, H, I, J> {
      * @param j the tenth parameter to verify
      * @return {@code true} if the test for the given parameters passes, {@code false} otherwise
      */
-    boolean verify(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j);
+    boolean verify(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion2.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion2.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,6 @@ public interface Assertion2<A, B> {
      * @param b the second parameter to verify
      * @return {@code true} if the test for the given parameters passes, {@code false} otherwise
      */
-    boolean verify(A a, B b);
+    boolean verify(A a, B b) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion3.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion3.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public interface Assertion3<A, B, C> {
      * @param c the third parameter to verify
      * @return {@code true} if the test for the given parameters passes, {@code false} otherwise
      */
-    boolean verify(A a, B b, C c);
+    boolean verify(A a, B b, C c) throws Throwable;
 
 }
 

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion4.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion4.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,6 @@ public interface Assertion4<A, B, C, D> {
      * @param d the fourth parameter to verify
      * @return {@code true} if the test for the given parameters passes, {@code false} otherwise
      */
-    boolean verify(A a, B b, C c, D d);
+    boolean verify(A a, B b, C c, D d) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion5.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion5.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,6 @@ public interface Assertion5<A, B, C, D, E> {
      * @param e the fifth parameter to verify
      * @return {@code true} if the test for the given parameters passes, {@code false} otherwise
      */
-    boolean verify(A a, B b, C c, D d, E e);
+    boolean verify(A a, B b, C c, D d, E e) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion6.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion6.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,6 @@ public interface Assertion6<A, B, C, D, E, F> {
      * @param f the sixth parameter to verify
      * @return {@code true} if the test for the given parameters passes, {@code false} otherwise
      */
-    boolean verify(A a, B b, C c, D d, E e, F f);
+    boolean verify(A a, B b, C c, D d, E e, F f) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion7.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion7.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,6 @@ public interface Assertion7<A, B, C, D, E, F, G> {
      * @param g the seventh parameter to verify
      * @return {@code true} if the test for the given parameters passes, {@code false} otherwise
      */
-    boolean verify(A a, B b, C c, D d, E e, F f, G g);
+    boolean verify(A a, B b, C c, D d, E e, F f, G g) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion8.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion8.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,6 @@ public interface Assertion8<A, B, C, D, E, F, G, H> {
      * @param h the eighth parameter to verify
      * @return {@code true} if the test for the given parameters passes, {@code false} otherwise
      */
-    boolean verify(A a, B b, C c, D d, E e, F f, G g, H h);
+    boolean verify(A a, B b, C c, D d, E e, F f, G g, H h) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion9.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Assertion9.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,6 @@ public interface Assertion9<A, B, C, D, E, F, G, H, I> {
      * @param i the ninth parameter to verify
      * @return {@code true} if the test for the given parameters passes, {@code false} otherwise
      */
-    boolean verify(A a, B b, C c, D d, E e, F f, G g, H h, I i);
+    boolean verify(A a, B b, C c, D d, E e, F f, G g, H h, I i) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable1.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable1.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable10.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable10.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable2.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable2.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable3.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable3.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable4.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable4.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable5.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable5.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable6.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable6.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable7.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable7.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable8.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable8.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable9.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/DataTable9.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations1.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations1.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations10.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations10.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations2.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations2.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations3.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations3.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations4.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations4.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations5.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations5.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations6.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations6.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations7.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations7.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations8.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations8.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations9.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Expectations9.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers1.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers1.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers10.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers10.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers2.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers2.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers3.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers3.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers4.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers4.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers5.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers5.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers6.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers6.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers7.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers7.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers8.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers8.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers9.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Headers9.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row1.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row1.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row10.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row10.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row2.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row2.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row3.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row3.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row4.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row4.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row5.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row5.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row6.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row6.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row7.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row7.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row8.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row8.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row9.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Row9.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification1.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification1.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,6 @@ public interface Verification1<A> {
      *
      * @param a the parameter to verify
      */
-    void verify(A a);
+    void verify(A a) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification10.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification10.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ public interface Verification10<A, B, C, D, E, F, G, H, I, J> {
      * @param i the ninth parameter to verify
      * @param j the tenth parameter to verify
      */
-    void verify(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j);
+    void verify(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification2.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification2.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,6 @@ public interface Verification2<A, B> {
      * @param a the first parameter to verify
      * @param b the second parameter to verify
      */
-    void verify(A a, B b);
+    void verify(A a, B b) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification3.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification3.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public interface Verification3<A, B, C> {
      * @param b the second parameter to verify
      * @param c the third parameter to verify
      */
-    void verify(A a, B b, C c);
+    void verify(A a, B b, C c) throws Throwable;
 
 }
 

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification4.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification4.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ public interface Verification4<A, B, C, D> {
      * @param c the third parameter to verify
      * @param d the fourth parameter to verify
      */
-    void verify(A a, B b, C c, D d);
+    void verify(A a, B b, C c, D d) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification5.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification5.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,6 @@ public interface Verification5<A, B, C, D, E> {
      * @param d the fourth parameter to verify
      * @param e the fifth parameter to verify
      */
-    void verify(A a, B b, C c, D d, E e);
+    void verify(A a, B b, C c, D d, E e) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification6.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification6.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,6 @@ public interface Verification6<A, B, C, D, E, F> {
      * @param e the fifth parameter to verify
      * @param f the sixth parameter to verify
      */
-    void verify(A a, B b, C c, D d, E e, F f);
+    void verify(A a, B b, C c, D d, E e, F f) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification7.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification7.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,6 @@ public interface Verification7<A, B, C, D, E, F, G> {
      * @param f the sixth parameter to verify
      * @param g the seventh parameter to verify
      */
-    void verify(A a, B b, C c, D d, E e, F f, G g);
+    void verify(A a, B b, C c, D d, E e, F f, G g) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification8.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification8.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,6 @@ public interface Verification8<A, B, C, D, E, F, G, H> {
      * @param g the seventh parameter to verify
      * @param h the eighth parameter to verify
      */
-    void verify(A a, B b, C c, D d, E e, F f, G g, H h);
+    void verify(A a, B b, C c, D d, E e, F f, G g, H h) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification9.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Verification9.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,6 @@ public interface Verification9<A, B, C, D, E, F, G, H, I> {
      * @param h the eighth parameter to verify
      * @param i the ninth parameter to verify
      */
-    void verify(A a, B b, C c, D d, E e, F f, G g, H h, I i);
+    void verify(A a, B b, C c, D d, E e, F f, G g, H h, I i) throws Throwable;
 
 }

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip1.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip1.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip10.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip10.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip2.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip2.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip3.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip3.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip4.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip4.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip5.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip5.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip6.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip6.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip7.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip7.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip8.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip8.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip9.java
+++ b/libs/expectations/src/main/java/builders/dsl/expectations/dsl/Zip9.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/test/java/builders/dsl/expectations/Calculator.java
+++ b/libs/expectations/src/test/java/builders/dsl/expectations/Calculator.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/expectations/src/test/java/builders/dsl/expectations/ExpectationsTest.java
+++ b/libs/expectations/src/test/java/builders/dsl/expectations/ExpectationsTest.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2024 Vladimir Orany.
+ * Copyright 2024-2025 Vladimir Orany.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
To allow usage of libraries that throws exceptions it's more convenient if the assertions and verifications functional interfaces throws `Throwable`